### PR TITLE
Corrected entrypoint target for PHP7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN mkdir -p /root/src \
     && rm -rf /root/src \
     && phpunit --version
 
-ENTRYPOINT ["/as-user","/usr/local/bin/phpunit","--colors=always"]
+ENTRYPOINT ["/run-as-user","/usr/local/bin/phpunit","--colors=always"]


### PR DESCRIPTION
After the update (at this time, 20 hours ago), all our builds fails testing, as `/System error: exec: "/as-user": stat /as-user: no such file or directory` - I saw in the base image, that it's `run-as-user` instead, so I made changes to reflect that.

Unfortunately, it's the third time this happens with the entrypoint, so I will build my own image, but I just thought I would make the PR at least :)

I haven't tested the PHP5 tag, so this only "fixes" the bug for PHP7.
